### PR TITLE
[Refactor] 인증 관련 메시지 및 파일 구조 정리

### DIFF
--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -4,6 +4,20 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import API_URL from "@/constants/config";
 
+const ACCESS_TOKEN_MAX_AGE = 60 * 60 * 2; // 2시간
+
+const setAuthCookie = (token: string) => {
+  cookies().set({
+    name: "accessToken",
+    value: token,
+    maxAge: ACCESS_TOKEN_MAX_AGE,
+    path: "/",
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+  });
+};
+
 // 로그인
 export const loginAction = async (data: { email: string; password: string }) => {
   const response = await fetch(`${API_URL}/auth/sign-in`, {
@@ -18,20 +32,12 @@ export const loginAction = async (data: { email: string; password: string }) => 
     throw new Error(result.message || "로그인 실패");
   }
 
-  cookies().set({
-    name: "accessToken",
-    value: result.accessToken,
-    maxAge: 60 * 60 * 24 * 7,
-    path: "/",
-    httpOnly: true,
-    sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
-  });
+  setAuthCookie(result.accessToken);
 
   redirect("/links?login=success");
 };
 
-// 회원가입
+// 회원가입 (성공 시 자동 로그인)
 export const signUpAction = async (data: { email: string; name: string; password: string }) => {
   const response = await fetch(`${API_URL}/auth/sign-up`, {
     method: "POST",
@@ -46,7 +52,9 @@ export const signUpAction = async (data: { email: string; name: string; password
     throw error;
   }
 
-  redirect("/login?signup=success");
+  setAuthCookie(result.accessToken);
+
+  redirect("/links?signup=success");
 };
 
 // 로그아웃

--- a/src/components/Login/LoginForm.tsx
+++ b/src/components/Login/LoginForm.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
 import { loginAction } from "@/actions/auth";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -21,15 +20,6 @@ const GUEST_CREDENTIALS = {
 const LoginForm = () => {
   const [isPending, setIsPending] = useState(false);
   const [isGuestPending, setIsGuestPending] = useState(false);
-  const searchParams = useSearchParams();
-  const router = useRouter();
-
-  useEffect(() => {
-    if (searchParams.get("signup") === "success") {
-      toast.success(toastMessages.success.signUp);
-      router.replace("/login");
-    }
-  }, [router, searchParams]);
 
   const {
     register,

--- a/src/components/Modal/components/FolderShareModal.tsx
+++ b/src/components/Modal/components/FolderShareModal.tsx
@@ -49,9 +49,9 @@ const FolderShareModal = ({ selectedItem }: { selectedItem: { id: number; name: 
   const handleShareToCopy = async () => {
     try {
       await navigator.clipboard.writeText(shareUrl);
-      toast.success(toastMessages.success.ShareCopy);
+      toast.success(toastMessages.success.shareCopy);
     } catch (error) {
-      toast.error(toastMessages.error.ShareCopy);
+      toast.error(toastMessages.error.shareCopy);
       console.error("클립보드 복사 실패:", error);
     }
     closeModal(`folderShare-${selectedItem.id}`);

--- a/src/components/Signup/SignupForm.tsx
+++ b/src/components/Signup/SignupForm.tsx
@@ -10,7 +10,7 @@ import FormContainer from "@/components/Layout/FormContainer";
 import CtaButton from "@/components/Button/CtaButton";
 import BaseInput from "@/components/Input/BaseInput";
 import LoadingSpinner from "@/components/common/LoadingSpinner";
-import { useCheckEmail } from "@/services/checkEmail";
+import { useCheckEmail } from "@/services/useCheckEmail";
 import { useDebounce } from "@/hooks/useDebounce";
 import { signUpAction } from "@/actions/auth";
 
@@ -59,7 +59,7 @@ const SignupForm = () => {
       }
 
       // 7. 그 외 일반 에러 (서버 오류 등)
-      toast.error(error?.message || toastMessages.error.signUp);
+      toast.error(error?.message || toastMessages.error.signup);
       setIsPending(false); // 8. 일반 에러 → 로딩 해제
     }
   };

--- a/src/lib/toastMessage.ts
+++ b/src/lib/toastMessage.ts
@@ -1,7 +1,7 @@
 const toastMessages = {
   success: {
-    login: "환영합니다! 🚀",
-    signUp: "회원가입이 완료됐습니다. 로그인해주세요 🎉",
+    login: "다시 오신 것을 환영합니다! 🚀",
+    signup: "가입을 환영합니다! 🎉",
     addLink: "링크가 추가됐습니다.",
     updateLink: "링크가 수정됐습니다.",
     deleteLink: "링크가 삭제됐습니다.",
@@ -10,11 +10,11 @@ const toastMessages = {
     addFolder: "폴더가 생성됐습니다.",
     updateFolder: "폴더 이름이 변경됐습니다.",
     deleteFolder: "폴더가 삭제됐습니다.",
-    ShareCopy: "링크가 복사됐습니다. 📋",
+    shareCopy: "링크가 복사됐습니다. 📋",
   },
   error: {
     login: "이메일 또는 비밀번호를 확인해주세요.",
-    signUp: "회원가입 중 오류가 발생했습니다. 다시 시도해주세요.",
+    signup: "회원가입 중 오류가 발생했습니다. 다시 시도해주세요.",
     addLink: "올바른 링크 URL을 입력해주세요.",
     updateLink: "링크 수정 중 오류가 발생했습니다.",
     deleteLink: "링크 삭제 중 오류가 발생했습니다.",
@@ -22,7 +22,7 @@ const toastMessages = {
     updateFolder: "폴더 이름 변경 중 오류가 발생했습니다.",
     deleteFolder: "폴더 안의 링크를 모두 삭제한 후 다시 시도해주세요.",
     favoriteLink: "즐겨찾기 처리 중 오류가 발생했습니다.",
-    ShareCopy: "복사 중 오류가 발생했습니다. 다시 시도해주세요.",
+    shareCopy: "복사 중 오류가 발생했습니다. 다시 시도해주세요.",
   },
 };
 

--- a/src/services/useCheckEmail.ts
+++ b/src/services/useCheckEmail.ts
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "@/constants/queryKeys";
 import { ApiError } from "@/types/api";
 
-export const checkEmail = async (email: string) => {
+const checkEmail = async (email: string) => {
   const res = await fetch(`${API_URL}/users/check-email`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
- checkEmail 훅 파일명 변경 (checkEmail.ts → useCheckEmail.ts)
- 회원가입 성공 시 자동 로그인 처리 및 /links로 리다이렉트
- toastMessages signUp → signup 키 통일 (success/error)
- 회원가입 성공 토스트 메시지 수정
- 회원가입 성공 시 자동 로그인으로 변경됨에 따라 LoginForm의 signup=success useEffect 제거