### PR TITLE
[Fix] API 에러 메시지 처리 로직 공통화

### DIFF
--- a/src/app/api/folders/[folderId]/links/route.ts
+++ b/src/app/api/folders/[folderId]/links/route.ts
@@ -1,21 +1,34 @@
 import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 import API_URL from "@/constants/config";
+import { getErrorMessage } from "@/lib/apiError";
+import toastMessages from "@/lib/toastMessage";
 
+// 폴더별 링크 조회
 export const GET = async (req: NextRequest, { params }: { params: { folderId: string } }) => {
   const token = cookies().get("accessToken")?.value;
-  if (!token) return NextResponse.json(null, { status: 401 });
+  if (!token) {
+    return NextResponse.json({ message: "로그인이 필요해요." }, { status: 401 });
+  }
 
   const { searchParams } = new URL(req.url);
   const { folderId } = params;
 
-  const res = await fetch(`${API_URL}/folders/${folderId}/links?${searchParams.toString()}`, {
-    headers: { Authorization: `Bearer ${token}` },
-    cache: "no-store",
-  });
+  try {
+    const res = await fetch(`${API_URL}/folders/${folderId}/links?${searchParams.toString()}`, {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
+    });
 
-  if (!res.ok) return NextResponse.json(null, { status: res.status });
+    if (!res.ok) {
+      const errorData = await res.json();
+      const message = getErrorMessage(errorData, res.status, toastMessages.error.getFolderLinks);
+      return NextResponse.json({ message }, { status: res.status });
+    }
 
-  const data = await res.json();
-  return NextResponse.json(data, { status: res.status });
+    return NextResponse.json(await res.json());
+  } catch (error) {
+    console.error("폴더별 링크 조회 중 오류 발생", error);
+    return NextResponse.json({ message: "서버와 연결이 원활하지 않아요. 잠시 후 다시 시도해주세요." }, { status: 500 });
+  }
 };

--- a/src/app/api/folders/[folderId]/route.ts
+++ b/src/app/api/folders/[folderId]/route.ts
@@ -1,12 +1,14 @@
 import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 import API_URL from "@/constants/config";
+import { getErrorMessage } from "@/lib/apiError";
+import toastMessages from "@/lib/toastMessage";
 
 // 폴더 수정
 export const PUT = async (req: NextRequest, { params }: { params: { folderId: string } }) => {
   const token = cookies().get("accessToken")?.value;
   if (!token) {
-    return NextResponse.json({ message: "인증 정보가 유효하지 않습니다." }, { status: 401 });
+    return NextResponse.json({ message: "로그인이 필요해요." }, { status: 401 });
   }
 
   const { name } = await req.json();
@@ -24,13 +26,14 @@ export const PUT = async (req: NextRequest, { params }: { params: { folderId: st
 
     if (!res.ok) {
       const errorData = await res.json();
-      return NextResponse.json({ message: errorData.message || "폴더 수정 실패" }, { status: res.status });
+      const message = getErrorMessage(errorData, res.status, toastMessages.error.updateFolder);
+      return NextResponse.json({ message }, { status: res.status });
     }
 
     return NextResponse.json(await res.json(), { status: res.status });
   } catch (error) {
-    console.error("폴더 수정 중 오류 발생", error);
-    return NextResponse.json({ message: "폴더 수정 실패" }, { status: 500 });
+    console.error("폴더별 링크 조회 중 오류 발생", error);
+    return NextResponse.json({ message: "서버와 연결이 원활하지 않아요. 잠시 후 다시 시도해주세요." }, { status: 500 });
   }
 };
 
@@ -38,7 +41,7 @@ export const PUT = async (req: NextRequest, { params }: { params: { folderId: st
 export const DELETE = async (_req: NextRequest, { params }: { params: { folderId: string } }) => {
   const token = cookies().get("accessToken")?.value;
   if (!token) {
-    return NextResponse.json({ message: "인증 정보가 유효하지 않습니다." }, { status: 401 });
+    return NextResponse.json({ message: "로그인이 필요해요." }, { status: 401 });
   }
 
   const { folderId } = params;
@@ -51,12 +54,13 @@ export const DELETE = async (_req: NextRequest, { params }: { params: { folderId
 
     if (!res.ok) {
       const errorData = await res.json();
-      return NextResponse.json({ message: errorData.message || "폴더 삭제 실패" }, { status: res.status });
+      const message = getErrorMessage(errorData, res.status, toastMessages.error.deleteFolder);
+      return NextResponse.json({ message }, { status: res.status });
     }
 
     return new NextResponse(null, { status: res.status });
   } catch (error) {
-    console.error("폴더 삭제 중 오류 발생", error);
-    return NextResponse.json({ message: "폴더 삭제 실패" }, { status: 500 });
+    console.error("폴더별 링크 조회 중 오류 발생", error);
+    return NextResponse.json({ message: "서버와 연결이 원활하지 않아요. 잠시 후 다시 시도해주세요." }, { status: 500 });
   }
 };

--- a/src/app/api/folders/route.ts
+++ b/src/app/api/folders/route.ts
@@ -1,12 +1,14 @@
 import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 import API_URL from "@/constants/config";
+import { getErrorMessage } from "@/lib/apiError";
+import toastMessages from "@/lib/toastMessage";
 
 // 폴더 조회
 export const GET = async () => {
   const token = cookies().get("accessToken")?.value;
   if (!token) {
-    return NextResponse.json({ message: "인증 정보가 유효하지 않습니다." }, { status: 401 });
+    return NextResponse.json({ message: "로그인이 필요해요." }, { status: 401 });
   }
 
   try {
@@ -17,13 +19,14 @@ export const GET = async () => {
 
     if (!res.ok) {
       const errorData = await res.json();
-      return NextResponse.json({ message: errorData.message || "폴더 조회 실패" }, { status: res.status });
+      const message = getErrorMessage(errorData, res.status, toastMessages.error.getFolder);
+      return NextResponse.json({ message }, { status: res.status });
     }
 
     return NextResponse.json(await res.json());
   } catch (error) {
     console.error("폴더 조회 중 오류 발생", error);
-    return NextResponse.json({ message: "폴더 조회 실패" }, { status: 500 });
+    return NextResponse.json({ message: "서버와 연결이 원활하지 않아요. 잠시 후 다시 시도해주세요." }, { status: 500 });
   }
 };
 
@@ -31,7 +34,7 @@ export const GET = async () => {
 export const POST = async (req: NextRequest) => {
   const token = cookies().get("accessToken")?.value;
   if (!token) {
-    return NextResponse.json({ message: "인증 정보가 유효하지 않습니다." }, { status: 401 });
+    return NextResponse.json({ message: "로그인이 필요해요." }, { status: 401 });
   }
 
   const { name } = await req.json();
@@ -48,12 +51,13 @@ export const POST = async (req: NextRequest) => {
 
     if (!res.ok) {
       const errorData = await res.json();
-      return NextResponse.json({ message: errorData.message || "폴더 생성 실패" }, { status: res.status });
+      const message = getErrorMessage(errorData, res.status, toastMessages.error.addFolder);
+      return NextResponse.json({ message }, { status: res.status });
     }
 
     return NextResponse.json(await res.json(), { status: res.status });
   } catch (error) {
     console.error("폴더 생성 중 오류 발생", error);
-    return NextResponse.json({ message: "폴더 생성 실패" }, { status: 500 });
+    return NextResponse.json({ message: "서버와 연결이 원활하지 않아요. 잠시 후 다시 시도해주세요." }, { status: 500 });
   }
 };

--- a/src/app/api/links/[linkId]/favorite/route.ts
+++ b/src/app/api/links/[linkId]/favorite/route.ts
@@ -1,12 +1,14 @@
 import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 import API_URL from "@/constants/config";
+import { getErrorMessage } from "@/lib/apiError";
+import toastMessages from "@/lib/toastMessage";
 
 // 즐겨찾기 설정
 export const PUT = async (req: NextRequest, { params }: { params: { linkId: string } }) => {
   const token = cookies().get("accessToken")?.value;
   if (!token) {
-    return NextResponse.json({ message: "인증 정보가 유효하지 않습니다." }, { status: 401 });
+    return NextResponse.json({ message: "로그인이 필요해요." }, { status: 401 });
   }
 
   const { favorite } = await req.json();
@@ -24,12 +26,13 @@ export const PUT = async (req: NextRequest, { params }: { params: { linkId: stri
 
     if (!res.ok) {
       const errorData = await res.json();
-      return NextResponse.json({ message: errorData.message }, { status: res.status });
+      const message = getErrorMessage(errorData, res.status, toastMessages.error.favoriteLink);
+      return NextResponse.json({ message }, { status: res.status });
     }
 
     return NextResponse.json(await res.json(), { status: res.status });
   } catch (error) {
-    console.error("즐겨찾기 설정 중 오류 발생", error);
-    return NextResponse.json({ message: "즐겨찾기 설정 실패" }, { status: 500 });
+    console.error("링크 수정 중 오류 발생", error);
+    return NextResponse.json({ message: "서버와 연결이 원활하지 않아요. 잠시 후 다시 시도해주세요." }, { status: 500 });
   }
 };

--- a/src/app/api/links/[linkId]/route.ts
+++ b/src/app/api/links/[linkId]/route.ts
@@ -1,12 +1,14 @@
 import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 import API_URL from "@/constants/config";
+import { getErrorMessage } from "@/lib/apiError";
+import toastMessages from "@/lib/toastMessage";
 
 // 링크 수정
 export const PUT = async (req: NextRequest, { params }: { params: { linkId: string } }) => {
   const token = cookies().get("accessToken")?.value;
   if (!token) {
-    return NextResponse.json({ message: "인증 정보가 유효하지 않습니다." }, { status: 401 });
+    return NextResponse.json({ message: "로그인이 필요해요." }, { status: 401 });
   }
 
   const { url } = await req.json();
@@ -24,13 +26,14 @@ export const PUT = async (req: NextRequest, { params }: { params: { linkId: stri
 
     if (!res.ok) {
       const errorData = await res.json();
-      return NextResponse.json({ message: errorData.message || "링크 수정 실패" }, { status: res.status });
+      const message = getErrorMessage(errorData, res.status, toastMessages.error.updateLink);
+      return NextResponse.json({ message }, { status: res.status });
     }
 
     return NextResponse.json(await res.json(), { status: res.status });
   } catch (error) {
     console.error("링크 수정 중 오류 발생", error);
-    return NextResponse.json({ message: "링크 수정 실패" }, { status: 500 });
+    return NextResponse.json({ message: "서버와 연결이 원활하지 않아요. 잠시 후 다시 시도해주세요." }, { status: 500 });
   }
 };
 
@@ -38,7 +41,7 @@ export const PUT = async (req: NextRequest, { params }: { params: { linkId: stri
 export const DELETE = async (_req: NextRequest, { params }: { params: { linkId: string } }) => {
   const token = cookies().get("accessToken")?.value;
   if (!token) {
-    return NextResponse.json({ message: "인증 정보가 유효하지 않습니다." }, { status: 401 });
+    return NextResponse.json({ message: "로그인이 필요해요." }, { status: 401 });
   }
 
   const { linkId } = params;
@@ -51,12 +54,13 @@ export const DELETE = async (_req: NextRequest, { params }: { params: { linkId: 
 
     if (!res.ok) {
       const errorData = await res.json();
-      return NextResponse.json({ message: errorData.message }, { status: res.status });
+      const message = getErrorMessage(errorData, res.status, toastMessages.error.deleteLink);
+      return NextResponse.json({ message }, { status: res.status });
     }
 
     return new NextResponse(null, { status: res.status });
   } catch (error) {
     console.error("링크 삭제 중 에러 발생", error);
-    return NextResponse.json({ message: "링크 삭제 실패" }, { status: 500 });
+    return NextResponse.json({ message: "서버와 연결이 원활하지 않아요. 잠시 후 다시 시도해주세요." }, { status: 500 });
   }
 };

--- a/src/app/api/links/route.ts
+++ b/src/app/api/links/route.ts
@@ -1,12 +1,14 @@
 import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 import API_URL from "@/constants/config";
+import { getErrorMessage } from "@/lib/apiError";
+import toastMessages from "@/lib/toastMessage";
 
 // 링크 조회
 export const GET = async (req: NextRequest) => {
   const token = cookies().get("accessToken")?.value;
   if (!token) {
-    return NextResponse.json({ message: "인증 정보가 유효하지 않습니다." }, { status: 401 });
+    return NextResponse.json({ message: "로그인이 필요해요." }, { status: 401 });
   }
 
   const { searchParams } = new URL(req.url);
@@ -19,13 +21,14 @@ export const GET = async (req: NextRequest) => {
 
     if (!res.ok) {
       const errorData = await res.json();
-      return NextResponse.json({ message: errorData.message || "링크 조회 실패" }, { status: res.status });
+      const message = getErrorMessage(errorData, res.status, toastMessages.error.getLinks);
+      return NextResponse.json({ message }, { status: res.status });
     }
 
     return NextResponse.json(await res.json());
   } catch (error) {
     console.error("링크 조회 중 에러 발생", error);
-    return NextResponse.json({ message: "링크 조회 실패" }, { status: 500 });
+    return NextResponse.json({ message: "서버와 연결이 원활하지 않아요. 잠시 후 다시 시도해주세요." }, { status: 500 });
   }
 };
 
@@ -33,7 +36,7 @@ export const GET = async (req: NextRequest) => {
 export const POST = async (req: NextRequest) => {
   const token = cookies().get("accessToken")?.value;
   if (!token) {
-    return NextResponse.json({ message: "인증 정보가 유효하지 않습니다." }, { status: 401 });
+    return NextResponse.json({ message: "로그인이 필요해요." }, { status: 401 });
   }
 
   const linkData = await req.json();
@@ -50,12 +53,13 @@ export const POST = async (req: NextRequest) => {
 
     if (!res.ok) {
       const errorData = await res.json();
-      return NextResponse.json({ message: errorData.message || "링크 생성 실패" }, { status: res.status });
+      const message = getErrorMessage(errorData, res.status, toastMessages.error.addLink);
+      return NextResponse.json({ message }, { status: res.status });
     }
 
     return NextResponse.json(await res.json(), { status: res.status });
   } catch (error) {
     console.error("링크 생성 중 에러 발생", error);
-    return NextResponse.json({ message: "링크 생성 실패" }, { status: 500 });
+    return NextResponse.json({ message: "서버와 연결이 원활하지 않아요. 잠시 후 다시 시도해주세요." }, { status: 500 });
   }
 };

--- a/src/lib/apiError.ts
+++ b/src/lib/apiError.ts
@@ -1,0 +1,10 @@
+const STATUS_MESSAGES: Record<number, string> = {
+  401: "로그인이 필요해요.",
+  403: "권한이 없거나 처리할 수 없는 요청이에요.",
+  404: "요청하신 항목을 찾을 수 없어요.",
+};
+
+export const getErrorMessage = (errorData: any, status: number, fallback: string) => {
+  if (STATUS_MESSAGES[status]) return STATUS_MESSAGES[status];
+  return errorData?.message || fallback;
+};

--- a/src/lib/toastMessage.ts
+++ b/src/lib/toastMessage.ts
@@ -15,13 +15,16 @@ const toastMessages = {
   error: {
     login: "이메일이나 비밀번호를 다시 확인해주세요.",
     signup: "회원가입 중 문제가 생겼어요. 다시 시도해주세요.",
+    getLinks: "링크 조회에 실패했어요.",
+    getFolderLinks: "폴더별 링크 조회에 실패했어요.",
     addLink: "올바른 링크를 입력해주세요.",
     updateLink: "링크 수정에 실패했어요.",
     deleteLink: "링크 삭제에 실패했어요.",
+    getFolder: "폴더 조회에 실패했어요.",
     addFolder: "폴더 이름을 다시 확인해주세요.",
     updateFolder: "폴더 이름 변경에 실패했어요.",
     deleteFolder: "폴더 안 링크를 먼저 삭제해주세요.",
-    favoriteLink: "즐겨찾기 처리에 실패했어요.",
+    favoriteLink: "즐겨찾기 설정에 실패했어요.",
     shareCopy: "복사에 실패했어요. 다시 시도해주세요.",
   },
 };

--- a/src/services/client/folders.ts
+++ b/src/services/client/folders.ts
@@ -2,7 +2,10 @@ import { Folder } from "@/types/folder";
 
 export const fetchFolders = async (): Promise<Folder[]> => {
   const res = await fetch(`/api/folders`);
-  if (!res.ok) throw new Error("폴더 조회 실패");
+  if (!res.ok) {
+    const error = await res.json();
+    throw new Error(error.message);
+  }
   return res.json();
 };
 
@@ -14,7 +17,7 @@ export const postFolders = async ({ name }: { name: string }) => {
   });
   if (!res.ok) {
     const error = await res.json();
-    throw new Error(error.message || "폴더 생성 실패");
+    throw new Error(error.message);
   }
   return res.json();
 };
@@ -27,7 +30,7 @@ export const putFolders = async ({ name, folderId }: { name: string; folderId: n
   });
   if (!res.ok) {
     const error = await res.json();
-    throw new Error(error.message || "폴더 수정 실패");
+    throw new Error(error.message);
   }
   return res.json();
 };
@@ -36,6 +39,6 @@ export const deleteFolders = async (folderId: number) => {
   const res = await fetch(`/api/folders/${folderId}`, { method: "DELETE" });
   if (!res.ok) {
     const error = await res.json();
-    throw new Error(error.message || "폴더 삭제 실패");
+    throw new Error(error.message);
   }
 };

--- a/src/services/client/links.ts
+++ b/src/services/client/links.ts
@@ -15,7 +15,10 @@ export const fetchLinks = async ({
   const endpoint = folderId ? `/api/folders/${folderId}/links` : "/api/links";
 
   const res = await fetch(`${endpoint}?${searchParams.toString()}`);
-  if (!res.ok) throw new Error("링크 조회 실패");
+  if (!res.ok) {
+    const error = await res.json();
+    throw new Error(error.message);
+  }
   return res.json();
 };
 
@@ -27,7 +30,7 @@ export const postLinks = async (linkData: CreateLinkParams) => {
   });
   if (!res.ok) {
     const error = await res.json();
-    throw new Error(error.message || "링크 생성 실패");
+    throw new Error(error.message);
   }
   return res.json();
 };
@@ -40,7 +43,7 @@ export const putLinks = async ({ url, linkId }: UpdateLinkParams) => {
   });
   if (!res.ok) {
     const error = await res.json();
-    throw new Error(error.message || "링크 수정 실패");
+    throw new Error(error.message);
   }
   return res.json();
 };
@@ -49,6 +52,6 @@ export const deleteLinks = async (linkId: number) => {
   const res = await fetch(`/api/links/${linkId}`, { method: "DELETE" });
   if (!res.ok) {
     const error = await res.json();
-    throw new Error(error.message || "링크 삭제 실패");
+    throw new Error(error.message);
   }
 };


### PR DESCRIPTION
- apiError.ts 추가: 상태 코드 기반 에러 메시지 공통 유틸(getErrorMessage) 구현
  - 401/403/404 백엔드 원본 메시지가 의미 없는 텍스트라 공통 문구로 고정
  - 그 외 상태는 백엔드가 제공하는 구체적 메시지를 우선 사용, 없으면 액션별 기본 메시지로 fallback
- links, folders 관련 API route(GET/POST/PUT/DELETE)에 공통 유틸 적용
- !res.ok(요청 오류)와 catch(서버/네트워크 오류)의 메시지를 구분하여 사용자에게 더 명확한 상황 안내 제공